### PR TITLE
Fix incorrect incident cooldown day in chat message

### DIFF
--- a/TwitchToolkit/TwitchToolkit.Incidents/StoreIncident.cs
+++ b/TwitchToolkit/TwitchToolkit.Incidents/StoreIncident.cs
@@ -17,4 +17,6 @@ public class StoreIncident : Def
 	public KarmaType karmaType;
 
 	public int variables = 0;
+
+	public bool IsItem => defName == "Item";
 }

--- a/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
@@ -190,14 +190,8 @@ public static class Purchase_Handler
 			return false;
 		}
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
-		return incident.karmaType switch
-		{
-			KarmaType.Bad => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval,
-			KarmaType.Good => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxGoodEventsPerInterval,
-			KarmaType.Neutral => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxNeutralEventsPerInterval,
-			KarmaType.Doom => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval,
-			_ => false,
-		};
+		int cap = Karma.GetKarmaCap(incident.karmaType);
+		return component.KarmaTypesInLogOf(incident.karmaType) >= cap;
 	}
 
 	public static bool CheckIfCarePackageIsOnCooldown(string username, bool separateChannel = false)

--- a/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -21,9 +22,10 @@ public static class Purchase_Handler
 	{
 		allStoreIncidentsSimple = DefDatabase<StoreIncidentSimple>.AllDefs.ToList();
 		allStoreIncidentsVariables = DefDatabase<StoreIncidentVariables>.AllDefs.ToList();
-		Helper.Log("trying to load vars after def database loaded");
-		((Mod)Toolkit.Mod).GetSettings<ToolkitSettings>();
 		viewerNamesDoingVariableCommands = new List<string>();
+
+		Helper.Log("trying to load vars after def database loaded");
+		Toolkit.Mod.GetSettings<ToolkitSettings>();
 	}
 
 	public static void ResolvePurchase(Viewer viewer, ITwitchMessage twitchMessage, bool separateChannel = false)
@@ -75,7 +77,7 @@ public static class Purchase_Handler
 	public static void ResolvePurchaseSimple(Viewer viewer, ITwitchMessage twitchMessage, StoreIncidentSimple incident, string formattedMessage, bool separateChannel = false)
 	{
 		int cost = incident.cost;
-		if (cost < 1 || CheckIfViewerIsInVariableCommandList(viewer.username) || !CheckIfViewerHasEnoughCoins(viewer, cost) || CheckIfKarmaTypeIsMaxed(incident, viewer.username) || CheckIfIncidentIsOnCooldown(incident, viewer.username))
+		if (cost < 1 || CheckIfViewerIsInVariableCommandList(viewer.username) || !CheckIfViewerHasEnoughCoins(viewer, cost) || IsPurchaseMaxed(incident, viewer.username))
 		{
 			return;
 		}
@@ -87,7 +89,7 @@ public static class Purchase_Handler
 		}
 		if (!helper.IsPossible())
 		{
-			TwitchWrapper.SendChatMessage(("@" + viewer.username + " " + Translator.Translate("TwitchToolkitEventNotPossible")));
+			TwitchWrapper.SendChatMessage("@" + viewer.username + " " + "TwitchToolkitEventNotPossible".Translate());
 			return;
 		}
 		if (!ToolkitSettings.UnlimitedCoins)
@@ -103,7 +105,7 @@ public static class Purchase_Handler
 		viewer.CalculateNewKarma(incident.karmaType, cost);
 		if (ToolkitSettings.PurchaseConfirmations)
 		{
-			TwitchWrapper.SendChatMessage(Helper.ReplacePlaceholder((Translator.Translate("TwitchToolkitEventPurchaseConfirm")), null, null, null, null, null, null, null, null, null, null, null, null, first: GenText.CapitalizeFirst(((Def)incident).label), viewer: viewer.username));
+			TwitchWrapper.SendChatMessage(Helper.ReplacePlaceholder("TwitchToolkitEventPurchaseConfirm".Translate(), first: GenText.CapitalizeFirst(incident.label), viewer: viewer.username));
 		}
 	}
 
@@ -114,18 +116,7 @@ public static class Purchase_Handler
 		{
 			return;
 		}
-		if (incident.IsItem)
-		{
-			if (CheckIfCarePackageIsOnCooldown(viewer.username))
-			{
-				return;
-			}
-		}
-		else if (CheckIfKarmaTypeIsMaxed(incident, viewer.username))
-		{
-			return;
-		}
-		if (CheckIfIncidentIsOnCooldown(incident, viewer.username))
+		if (IsPurchaseMaxed(incident, viewer.username))
 		{
 			return;
 		}
@@ -133,7 +124,7 @@ public static class Purchase_Handler
 		IncidentHelperVariables helper = StoreIncidentMaker.MakeIncidentVariables(incident);
 		if (helper == null)
 		{
-			Helper.Log("Missing helper for incident " + ((Def)incident).defName);
+			Helper.Log("Missing helper for incident " + incident.defName);
 			return;
 		}
 		if (!helper.IsPossible(formattedMessage, viewer))
@@ -159,6 +150,7 @@ public static class Purchase_Handler
 			TwitchWrapper.SendChatMessage("@" + username + " you must wait for the game to unpause to buy something else.");
 			return true;
 		}
+
 		return false;
 	}
 
@@ -166,21 +158,26 @@ public static class Purchase_Handler
 	{
 		if (!ToolkitSettings.UnlimitedCoins && viewer.GetViewerCoins() < finalPrice)
 		{
-			TwitchWrapper.SendChatMessage(Helper.ReplacePlaceholder((TaggedString)(Translator.Translate("TwitchToolkitNotEnoughCoins")), null, null, null, null, null, null, null, null, null, null, viewer: viewer.username, amount: finalPrice.ToString(), mod: null, newbalance: null, karma: null, first: viewer.GetViewerCoins().ToString()));
+			TwitchWrapper.SendChatMessage(Helper.ReplacePlaceholder("TwitchToolkitNotEnoughCoins".Translate(), viewer: viewer.username, amount: finalPrice.ToString(), first: viewer.GetViewerCoins().ToString()));
 			return false;
 		}
+
 		return true;
 	}
 
+	[Obsolete]
 	public static bool CheckIfKarmaTypeIsMaxed(StoreIncident incident, string username, bool separateChannel = false)
 	{
-		bool maxed = CheckTimesKarmaTypeHasBeenUsedRecently(incident);
-		if (maxed)
+		if (CheckTimesKarmaTypeHasBeenUsedRecently(incident))
 		{
 			Store_Component component = Current.Game.GetComponent<Store_Component>();
-			TwitchWrapper.SendChatMessage("@" + username + " " + GenText.CapitalizeFirst(((Def)incident).label) + " is maxed from karmatype, wait " + component.DaysTillIncidentIsPurchaseable(incident) + " days to purchase.");
+
+			float daysTill = component.DaysTillIncidentIsPurchaseable(incident);
+			TwitchWrapper.SendChatMessage($"@{username} {GenText.CapitalizeFirst(incident.label)} is maxed from karmatype, wait {GetDays(daysTill)} to purchase.");
+			return true;
 		}
-		return maxed;
+
+		return false;
 	}
 
 	public static bool CheckTimesKarmaTypeHasBeenUsedRecently(StoreIncident incident)
@@ -189,42 +186,49 @@ public static class Purchase_Handler
 		{
 			return false;
 		}
+
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
 		int cap = Karma.GetKarmaCap(incident.karmaType);
 		return component.KarmaTypesInLogOf(incident.karmaType) >= cap;
 	}
 
+	[Obsolete]
 	public static bool CheckIfCarePackageIsOnCooldown(string username, bool separateChannel = false)
 	{
 		if (!ToolkitSettings.MaxEvents)
 		{
 			return false;
 		}
+
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
 		StoreIncidentVariables incident = DefDatabase<StoreIncidentVariables>.GetNamed("Item", true);
 		if (component.IncidentsInLogOf(incident.abbreviation) >= ToolkitSettings.MaxCarePackagesPerInterval)
 		{
 			float daysTill = component.DaysTillIncidentIsPurchaseable(incident);
-			TwitchWrapper.SendChatMessage("@" + username + " care packages are on cooldown, wait " + daysTill + " day" + ((daysTill != 1f) ? "s" : "") + ".");
+			TwitchWrapper.SendChatMessage($"@{username} care packages are on cooldown, wait {GetDays(daysTill)}.");
 			return true;
 		}
+
 		return false;
 	}
 
+	[Obsolete]
 	public static bool CheckIfIncidentIsOnCooldown(StoreIncident incident, string username, bool separateChannel = false)
 	{
 		if (!ToolkitSettings.EventsHaveCooldowns)
 		{
 			return false;
 		}
+
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
-		bool maxed = component.IncidentsInLogOf(incident.abbreviation) >= incident.eventCap;
-		if (maxed)
+		if (component.IncidentsInLogOf(incident.abbreviation) >= incident.eventCap)
 		{
-			float days = component.DaysTillIncidentIsPurchaseable(incident);
-			TwitchWrapper.SendChatMessage("@" + username + " " + GenText.CapitalizeFirst(((Def)incident).label) + " is maxed, wait " + days + " day" + ((days != 1f) ? "s" : "") + " to purchase.");
+			float daysTill = component.DaysTillIncidentIsPurchaseable(incident);
+			TwitchWrapper.SendChatMessage($"@{username} {GenText.CapitalizeFirst(incident.label)} is maxed, wait {GetDays(daysTill)} to purchase.");
+			return true;
 		}
-		return maxed;
+
+		return false;
 	}
 
 	public static void QueuePlayerMessage(Viewer viewer, string message, int variables = 0)
@@ -248,30 +252,49 @@ public static class Purchase_Handler
 		Helper.playerMessages.Add(output);
 	}
 
+	private static bool IsPurchaseMaxed(StoreIncident incident, string username)
+	{
+		Store_Component component = Current.Game.GetComponent<Store_Component>();
+
+		float daysTill = component.DaysTillIncidentIsPurchaseable(incident, out bool isKarma);
+		if (daysTill < 0)
+		{
+			return false;
+		}
+
+		string days = GetDays(daysTill);
+
+		if (isKarma)
+		{
+			TwitchWrapper.SendChatMessage($"@{username} {GenText.CapitalizeFirst(incident.label)} is maxed from karmatype, wait {days} to purchase.");
+		}
+		else if (incident.IsItem)
+		{
+			TwitchWrapper.SendChatMessage($"@{username} care packages are on cooldown, wait {days}.");
+		}
+		else
+		{
+			TwitchWrapper.SendChatMessage($"@{username} {GenText.CapitalizeFirst(incident.label)} is maxed, wait {days} to purchase.");
+		}
+
+		return true;
+	}
+
+	private static string GetDays(float days) => (days == 1) ? "1 day" : days + " days";
+
 	private static string AdminText(string input)
 	{
-		char[] chars = input.ToCharArray();
 		StringBuilder output = new StringBuilder();
-		char[] array = chars;
-		foreach (char str in array)
+		foreach (char str in input.ToCharArray())
 		{
 			output.Append($"<color=#{Helper.GetRandomColorCode()}>{str}</color>");
 		}
 		return output.ToString();
 	}
 
-	private static string SubText(string input)
-	{
-		return "<color=#D9BB25>" + input + "</color>";
-	}
+	private static string SubText(string input) => "<color=#D9BB25>" + input + "</color>";
 
-	private static string VIPText(string input)
-	{
-		return "<color=#5F49F2>" + input + "</color>";
-	}
+	private static string VIPText(string input) => "<color=#5F49F2>" + input + "</color>";
 
-	private static string ModText(string input)
-	{
-		return "<color=#238C48>" + input + "</color>";
-	}
+	private static string ModText(string input) => "<color=#238C48>" + input + "</color>";
 }

--- a/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Purchase_Handler.cs
@@ -74,7 +74,7 @@ public static class Purchase_Handler
 
 	public static void ResolvePurchaseSimple(Viewer viewer, ITwitchMessage twitchMessage, StoreIncidentSimple incident, string formattedMessage, bool separateChannel = false)
 	{
-        int cost = incident.cost;
+		int cost = incident.cost;
 		if (cost < 1 || CheckIfViewerIsInVariableCommandList(viewer.username) || !CheckIfViewerHasEnoughCoins(viewer, cost) || CheckIfKarmaTypeIsMaxed(incident, viewer.username) || CheckIfIncidentIsOnCooldown(incident, viewer.username))
 		{
 			return;
@@ -110,18 +110,18 @@ public static class Purchase_Handler
 	public static void ResolvePurchaseVariables(Viewer viewer, ITwitchMessage twitchMessage, StoreIncidentVariables incident, string formattedMessage, bool separateChannel = false)
 	{
 		int cost = incident.cost;
-		if ((cost < 1 && ((Def)incident).defName != "Item") || CheckIfViewerIsInVariableCommandList(viewer.username) || !CheckIfViewerHasEnoughCoins(viewer, cost))
+		if ((cost < 1 && !incident.IsItem) || CheckIfViewerIsInVariableCommandList(viewer.username) || !CheckIfViewerHasEnoughCoins(viewer, cost))
 		{
 			return;
 		}
-		if (incident != DefDatabase<StoreIncidentVariables>.GetNamed("Item", true))
+		if (incident.IsItem)
 		{
-			if (CheckIfKarmaTypeIsMaxed(incident, viewer.username))
+			if (CheckIfCarePackageIsOnCooldown(viewer.username))
 			{
 				return;
 			}
 		}
-		else if (CheckIfCarePackageIsOnCooldown(viewer.username))
+		else if (CheckIfKarmaTypeIsMaxed(incident, viewer.username))
 		{
 			return;
 		}
@@ -192,11 +192,11 @@ public static class Purchase_Handler
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
 		return incident.karmaType switch
 		{
-			KarmaType.Bad => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval, 
-			KarmaType.Good => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxGoodEventsPerInterval, 
-			KarmaType.Neutral => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxNeutralEventsPerInterval, 
-			KarmaType.Doom => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval, 
-			_ => false, 
+			KarmaType.Bad => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval,
+			KarmaType.Good => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxGoodEventsPerInterval,
+			KarmaType.Neutral => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxNeutralEventsPerInterval,
+			KarmaType.Doom => component.KarmaTypesInLogOf(incident.karmaType) >= ToolkitSettings.MaxBadEventsPerInterval,
+			_ => false,
 		};
 	}
 

--- a/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
@@ -63,12 +63,25 @@ public class Store_Component : GameComponent
 		return karmaHistory.Count((KeyValuePair<int, string> pair) => pair.Value == karma);
 	}
 
-	public float DaysTillIncidentIsPurchaseable(StoreIncident incident)
+	public float DaysTillIncidentIsPurchaseable(StoreIncident incident) => DaysTillIncidentIsPurchaseable(incident, out _);
+
+	public float DaysTillIncidentIsPurchaseable(StoreIncident incident, out bool isKarmaCapped)
 	{
 		int karmaTick = GetKarmaOrItemCooldown(incident);
 		int capTick = GetIncidentCooldown(incident);
 
-		int cooldownTick = Math.Max(karmaTick, capTick);
+		int cooldownTick;
+		if (karmaTick >= capTick)
+		{
+			cooldownTick = karmaTick;
+			isKarmaCapped = true;
+		}
+		else
+		{
+			cooldownTick = capTick;
+			isKarmaCapped = false;
+		}
+
 		if (cooldownTick < 0)
 		{
 			return -1;

--- a/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
@@ -63,7 +63,7 @@ public class Store_Component : GameComponent
 		List<int> associateLogIDS = new List<int>();
 		float ticksTillExpires = -1f;
 		float daysTillCooldownExpires = -1f;
-		if (((Def)incident).defName == "Item")
+		if (incident.IsItem)
 		{
 			if (ToolkitSettings.MaxEvents)
 			{

--- a/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
+++ b/TwitchToolkit/TwitchToolkit.Store/Store_Component.cs
@@ -1,3 +1,4 @@
+using RimWorld;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,6 +9,8 @@ namespace TwitchToolkit.Store;
 
 public class Store_Component : GameComponent
 {
+	private static int EventCooldownInDays => GenDate.TicksPerDay * ToolkitSettings.EventCooldownInterval;
+
 	public int lastID = 0;
 
 	public Dictionary<int, int> tickHistory = new Dictionary<int, int>();
@@ -32,13 +35,15 @@ public class Store_Component : GameComponent
 	{
 		int currentTick = Find.TickManager.TicksGame;
 		List<int> toRemove = new List<int>();
+
 		foreach (KeyValuePair<int, int> pair in tickHistory)
 		{
-			if (pair.Value + 60000 * ToolkitSettings.EventCooldownInterval < currentTick)
+			if (pair.Value + EventCooldownInDays < currentTick)
 			{
 				toRemove.Add(pair.Key);
 			}
 		}
+
 		foreach (int i in toRemove)
 		{
 			tickHistory.Remove(i);
@@ -49,96 +54,95 @@ public class Store_Component : GameComponent
 
 	public int IncidentsInLogOf(string abbreviation)
 	{
-		return abbreviationHistory.Where((KeyValuePair<int, string> pair) => pair.Value == abbreviation).Count();
+		return abbreviationHistory.Count((KeyValuePair<int, string> pair) => pair.Value == abbreviation);
 	}
 
 	public int KarmaTypesInLogOf(KarmaType karmaType)
 	{
-		return karmaHistory.Where((KeyValuePair<int, string> pair) => pair.Value == karmaType.ToString()).Count();
+		var karma = karmaType.ToString();
+		return karmaHistory.Count((KeyValuePair<int, string> pair) => pair.Value == karma);
 	}
 
 	public float DaysTillIncidentIsPurchaseable(StoreIncident incident)
 	{
-		Store_Component component = Current.Game.GetComponent<Store_Component>();
-		List<int> associateLogIDS = new List<int>();
-		float ticksTillExpires = -1f;
-		float daysTillCooldownExpires = -1f;
-		if (incident.IsItem)
+		int karmaTick = GetKarmaOrItemCooldown(incident);
+		int capTick = GetIncidentCooldown(incident);
+
+		int cooldownTick = Math.Max(karmaTick, capTick);
+		if (cooldownTick < 0)
 		{
-			if (ToolkitSettings.MaxEvents)
-			{
-				int logged4 = component.IncidentsInLogOf(incident.abbreviation);
-				bool onCooldownByKarmaType = logged4 >= ToolkitSettings.MaxCarePackagesPerInterval;
-			}
-			if (ToolkitSettings.EventsHaveCooldowns)
-			{
-				int logged3 = component.IncidentsInLogOf(incident.abbreviation);
-				bool onCooldownByIncidentCap = logged3 >= incident.eventCap;
-			}
-			foreach (KeyValuePair<int, string> pair3 in abbreviationHistory)
-			{
-				if (pair3.Value == incident.abbreviation)
-				{
-					associateLogIDS.Add(pair3.Key);
-				}
-			}
+			return -1;
 		}
-		else
-		{
-			if (ToolkitSettings.MaxEvents)
-			{
-				int logged2 = component.KarmaTypesInLogOf(incident.karmaType);
-				bool onCooldownByKarmaType = Purchase_Handler.CheckTimesKarmaTypeHasBeenUsedRecently(incident);
-			}
-			if (ToolkitSettings.EventsHaveCooldowns)
-			{
-				int logged = component.IncidentsInLogOf(incident.abbreviation);
-				bool onCooldownByIncidentCap = logged >= incident.eventCap;
-			}
-			foreach (KeyValuePair<int, string> pair2 in abbreviationHistory)
-			{
-				if (pair2.Value == incident.abbreviation)
-				{
-					associateLogIDS.Add(pair2.Key);
-				}
-			}
-			foreach (KeyValuePair<int, string> pair in karmaHistory)
-			{
-				if (pair.Value == incident.karmaType.ToString())
-				{
-					associateLogIDS.Add(pair.Key);
-				}
-			}
-		}
-		foreach (int id in associateLogIDS)
-		{
-			float ticksAgo = Find.TickManager.TicksGame - tickHistory[id];
-			float daysAgo = ticksAgo / 60000f;
-			float ticksTillExpiration = (float)(ToolkitSettings.EventCooldownInterval * 60000) - ticksAgo;
-			if (ticksTillExpires == -1f || ticksAgo < ticksTillExpiration)
-			{
-				ticksTillExpires = ticksAgo;
-				daysTillCooldownExpires = ticksTillExpiration / 60000f;
-			}
-		}
-		return (float)Math.Round(daysTillCooldownExpires, 1);
+
+		int currentTick = Find.TickManager.TicksGame;
+		float expirationDays = ((float)(cooldownTick + EventCooldownInDays - currentTick)) / GenDate.TicksPerDay;
+		return (float)Math.Round(expirationDays, 1);
 	}
 
 	public void LogIncident(StoreIncident incident)
 	{
 		int currentTick = Find.TickManager.TicksGame;
 		int logID = lastID;
+
 		tickHistory.Add(logID, currentTick);
 		abbreviationHistory.Add(logID, incident.abbreviation);
 		karmaHistory.Add(logID, incident.karmaType.ToString());
+
 		lastID++;
 	}
 
 	public override void ExposeData()
 	{
-		Scribe_Values.Look<int>(ref lastID, "logID", 0, false);
-		Scribe_Collections.Look<int, int>(ref tickHistory, "tickHistory", (LookMode)1, (LookMode)1);
-		Scribe_Collections.Look<int, string>(ref abbreviationHistory, "incidentHistory", (LookMode)1, (LookMode)1);
-		Scribe_Collections.Look<int, string>(ref karmaHistory, "karmaHistory", (LookMode)1, (LookMode)1);
+		Scribe_Values.Look(ref lastID, "logID", 0);
+		Scribe_Collections.Look(ref tickHistory, "tickHistory", LookMode.Value, LookMode.Value);
+		Scribe_Collections.Look(ref abbreviationHistory, "incidentHistory", LookMode.Value, LookMode.Value);
+		Scribe_Collections.Look(ref karmaHistory, "karmaHistory", LookMode.Value, LookMode.Value);
+	}
+
+	private int GetKarmaOrItemCooldown(StoreIncident incident)
+	{
+		if (!ToolkitSettings.MaxEvents)
+		{
+			return -1;
+		}
+
+		if (incident.IsItem)
+		{
+			return FindMinIfCapped(abbreviationHistory, incident.abbreviation, ToolkitSettings.MaxCarePackagesPerInterval);
+		}
+
+		return FindMinIfCapped(karmaHistory, incident.karmaType.ToString(), Karma.GetKarmaCap(incident.karmaType));
+	}
+
+	private int GetIncidentCooldown(StoreIncident incident)
+	{
+		if (!ToolkitSettings.EventsHaveCooldowns)
+		{
+			return -1;
+		}
+
+		return FindMinIfCapped(abbreviationHistory, incident.abbreviation, incident.eventCap);
+	}
+
+	private int FindMinIfCapped(IEnumerable<KeyValuePair<int, string>> collection, string criteria, int needed)
+	{
+		int count = 0;
+		int minTick = int.MaxValue;
+
+		foreach (KeyValuePair<int, string> pair in collection)
+		{
+			if (pair.Value == criteria)
+			{
+				count++;
+				minTick = Math.Min(minTick, tickHistory[pair.Key]);
+			}
+		}
+
+		if (count >= needed)
+		{
+			return minTick;
+		}
+
+		return -1;
 	}
 }

--- a/TwitchToolkit/TwitchToolkit.Windows/StoreIncidentEditor.cs
+++ b/TwitchToolkit/TwitchToolkit.Windows/StoreIncidentEditor.cs
@@ -91,7 +91,7 @@ public class StoreIncidentEditor : Window
 			}
 		}
 		((Listing)ls).Gap(12f);
-		if (((Def)storeIncident).defName == "Item")
+		if (storeIncident.IsItem)
 		{
 			ls.SliderLabeled("Max times per " + ToolkitSettings.EventCooldownInterval + " ingame day(s)",  storeIncident.eventCap, storeIncident.eventCap.ToString(), 0f, 15f);
 			((Listing)ls).Gap(12f);
@@ -105,7 +105,7 @@ public class StoreIncidentEditor : Window
 			}
 		}
 		((Listing)ls).Gap(12f);
-		if (((Def)storeIncident).defName != "Item" && ls.ButtonTextLabeled("Reset to Default", "Reset"))
+		if (!storeIncident.IsItem && ls.ButtonTextLabeled("Reset to Default", "Reset"))
 		{
 			Store_IncidentEditor.LoadBackup(storeIncident);
 			if (storeIncident.cost < 1)
@@ -115,7 +115,7 @@ public class StoreIncidentEditor : Window
 			setKarmaType = storeIncident.karmaType.ToString();
 			MakeSureSaveExists();
 		}
-		if (((Def)storeIncident).defName == "Item" && ls.ButtonTextLabeled("Edit item prices", "Edit"))
+		if (storeIncident.IsItem && ls.ButtonTextLabeled("Edit item prices", "Edit"))
 		{
 			Type type = typeof(StoreItemsWindow);
 			Find.WindowStack.TryRemove(type, true);

--- a/TwitchToolkit/TwitchToolkit.Windows/StoreIncidentsWindow.cs
+++ b/TwitchToolkit/TwitchToolkit.Windows/StoreIncidentsWindow.cs
@@ -98,7 +98,7 @@ public class StoreIncidentsWindow : Window
 		Rect rect3 = new Rect(rect2.xMax + 4f, 0f, ((Rect)(rect)).width - 60f, 24f);
 		Text.Anchor =((TextAnchor)3);
 		Text.WordWrap =(false);
-		if (thingDef.cost < 1 && ((Def)thingDef).defName != "Item")
+		if (thingDef.cost < 1 && !thingDef.IsItem)
 		{
 			GUI.color =(Color.grey);
 		}

--- a/TwitchToolkit/TwitchToolkit/Karma.cs
+++ b/TwitchToolkit/TwitchToolkit/Karma.cs
@@ -114,6 +114,17 @@ public class Karma
 		return (Convert.ToInt32(Math.Ceiling(newkarma)) > ToolkitSettings.KarmaCap) ? ToolkitSettings.KarmaCap : Convert.ToInt32(Math.Ceiling(newkarma));
 	}
 
+	internal static int GetKarmaCap(KarmaType karmaType)
+	{
+		return karmaType switch
+		{
+			KarmaType.Bad or KarmaType.Doom => ToolkitSettings.MaxBadEventsPerInterval,
+			KarmaType.Good => ToolkitSettings.MaxGoodEventsPerInterval,
+			KarmaType.Neutral => ToolkitSettings.MaxNeutralEventsPerInterval,
+			_ => int.MaxValue,
+		};
+	}
+
 	private static float CalculateForCurve()
 	{
 		return 0.00116279069f * (float)ToolkitSettings.KarmaCap + 0.8372093f;


### PR DESCRIPTION
This MR fixes incorrect event\item cooldown day in chat message.

See hodlhodl1132/twitchtoolkit#67 for more information.